### PR TITLE
Rework of build container 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM debian:latest
+FROM debian:stretch
 
 LABEL maintainer="Austin Hunting"
 LABEL maintainer_email="austin.hunting@hpe.com"
 
 ENV DEBIAN_FRONTEND=noninteractive
-
 RUN apt-get update && apt-get -y install git
 
-# WORKDIR is /
-COPY builder.bash /builder.bash
+CMD git clone https://github.com/AustinHunting/l4fame-build-container.git; \
+    ( cd l4fame-build-container && git stash && git pull ); \
+    ( cd l4fame-build-container && bash builder.bash );
 
-CMD /builder.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:stretch
-# TODO: From his
 #FROM debian:latest
 
 LABEL maintainer="Austin Hunting"
@@ -9,7 +8,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN touch .in_docker_container
 RUN apt-get update && apt-get -y install git
 
-# TODO: From mine
 #CMD git clone https://github.com/FabricAttachedMemory/l4fame-build-container.git; \
 #    ( cd l4fame-build-container && git stash && git pull ); \
 #    ( cd l4fame-build-container && bash builder.bash );

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:stretch
-#FROM debian:latest
 
 LABEL maintainer="Austin Hunting"
 LABEL maintainer_email="austin.hunting@hpe.com"
@@ -7,10 +6,6 @@ LABEL maintainer_email="austin.hunting@hpe.com"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN touch .in_docker_container
 RUN apt-get update && apt-get -y install git
-
-#CMD git clone https://github.com/FabricAttachedMemory/l4fame-build-container.git; \
-#    ( cd l4fame-build-container && git stash && git pull ); \
-#    ( cd l4fame-build-container && bash builder.bash );
 
 # WORKDIR is /
 COPY builder.bash /builder.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN touch .in_docker_container
 RUN apt-get update && apt-get -y install git
 
+
+# TODO: Added cp builder to satisfy using basename $0 over $0
+# TODO: Will remove in favor of other method
 CMD git clone https://github.com/AustinHunting/l4fame-build-container.git; \
     ( cd l4fame-build-container && git stash && git pull ); \
-    ( cd l4fame-build-container && bash builder.bash );
+    ( cp /l4fame-build-container/builder.bash / && bash /builder.bash );
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM debian:stretch
+# TODO: From his
+#FROM debian:latest
 
 LABEL maintainer="Austin Hunting"
 LABEL maintainer_email="austin.hunting@hpe.com"
@@ -7,10 +9,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN touch .in_docker_container
 RUN apt-get update && apt-get -y install git
 
+# TODO: From mine
+#CMD git clone https://github.com/FabricAttachedMemory/l4fame-build-container.git; \
+#    ( cd l4fame-build-container && git stash && git pull ); \
+#    ( cd l4fame-build-container && bash builder.bash );
 
-# TODO: Added cp builder to satisfy using basename $0 over $0
-# TODO: Will remove in favor of other method
-CMD git clone https://github.com/AustinHunting/l4fame-build-container.git; \
-    ( cd l4fame-build-container && git stash && git pull ); \
-    ( cp /l4fame-build-container/builder.bash / && bash /builder.bash );
-
+# WORKDIR is /
+COPY builder.bash /builder.bash
+CMD /builder.bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Austin Hunting"
 LABEL maintainer_email="austin.hunting@hpe.com"
 
 ENV DEBIAN_FRONTEND=noninteractive
+RUN touch .in_docker_container
 RUN apt-get update && apt-get -y install git
 
 CMD git clone https://github.com/AustinHunting/l4fame-build-container.git; \

--- a/README.md
+++ b/README.md
@@ -36,15 +36,6 @@ add
 ```
 to the arguments.
 
-### Pull from Dockerhub
-
-As an alternative to building the image locally, obtain it from the prebuilt
-image from Dockerhub.
-
-```
-docker pull austinhpe/l4fame-build-container
-```
-
 ## Launching the Docker container
 
 Once the Docker image has been built or downloaded it needs to be run.
@@ -59,11 +50,6 @@ Downloaded and built locally:
 docker run -t --name l4fame-build --privileged -v ~/theDebs:/debs -v L4FAME_BUILD:/build ~/deb:/deb l4fame-build
 ```
 
-Pulled down from Dockerhub:
-```
-docker run -t --name l4fame-build --privileged -v ~/theDebs:/debs -v L4FAME_BUILD:/build austinhpe/l4fame-build-container
-```
-
 To disconnect from the container without killing it run `Ctrl+C`
 
 To reconnect to the container run `docker attach l4fame-builder`
@@ -71,7 +57,7 @@ To reconnect to the container run `docker attach l4fame-builder`
 
 | Docker Flag | Explanation |
 | ----------- | ----------- |
-| `-t` | Allocates and attaches a pseudo-tty, this allows the container to be killed (ctl-C) or sent to the background. |
+| `-t` | Allocates and attaches a pseudo-tty, this allows the container to be killed (Ctrl-C) or sent to the background. |
 | `--name l4fame-build` | Names the container "l4fame-build" to simplify subsequent runs. |
 | `--privileged` | Gives the container enough privileges to enter a chroot and build arm64 packages. |
 | `-v L4FAME_BUILD:/build` | Creates a new Docker volume named L4FAME_BUILD to hold packages and temporary files as they are being built. |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Instructions for building individual packages can be found **[here](BuildRules.m
 
 ## External Links
 
-* [l4fame-build-container](https://hub.docker.com/r/austinhpe/l4fame-build-container/) - Dockerhub image for the build container
 * [debserve](https://hub.docker.com/r/davidpatawaran/debserve/) - Dockerhub image for debserve
 
 ## License

--- a/builder.bash
+++ b/builder.bash
@@ -496,9 +496,6 @@ set_debuild_config
 # This is what works, trial and error, I stopped at first working solution.
 # They might not be optimal or use minimal set of --git-upstream-xxx options.
 
-# TODO: It doesn't seem like there is anything preventing x86 builds when the
-#       repo is un-updated
-
 for REPO in l4fame-node l4fame-manager tm-libfuse tm-librarian; do
     get_update_path ${REPO}.git && build_via_gbp
 done
@@ -529,10 +526,7 @@ build_kernel
 #--------------------------------------------------------------------------
 # That's all, folks!  Move what worked.
 
-# TODO: Do we want to copy the source packages as well?
 copy_built_packages
-#cp $GBPOUT/*.deb $DEBS
-#cp $GBPOUT/*.changes $DEBS
 
 newlog $MASTERLOG
 let ELAPSED=$(date +%s)-ELAPSED

--- a/builder.bash
+++ b/builder.bash
@@ -331,11 +331,11 @@ function build_kernel() {
     make -j$CORES deb-pkg 2>&1 | tee -a $LOGFILE
     collect_errors
 
+    # They end up one above $GITPATH???
+    # NOTE: Ans, yep one above $GITPATH super annoying
+    mv -f $BUILD/linux*.* $GBPOUT   # Keep them with all the others
     # We can check if make was successful by looking for $BUILD/linux*.*
-    if [ -f $BUILD/linux*.* ]; then
-        # They end up one above $GITPATH???
-        # NOTE: Ans, yep one above $GITPATH super annoying
-        mv -f $BUILD/linux*.* $GBPOUT   # Keep them with all the others
+    if [ $? -eq 0 ]; then
         # If make was successful remove the update build flag
         if inContainer; then
             rm ../$(basename $(pwd))-AMD-update

--- a/builder.bash
+++ b/builder.bash
@@ -429,15 +429,15 @@ if inContainer; then     # Create the directories used in "docker run -v"
     mkdir -p $DEBS      # Root of the container
 else
     log "NOT in container"
+    # Not sure what "linux-image-arm64" gets us. Pulled from Keith's build script
     # apt-get install -y linux-image-arm64  Austin's first try?
-    # NOTE: Not sure what "linux-image-arm64" gets us. Pulled from Keith's build script
 fi
 
 apt-get update && apt-get upgrade -y
 apt-get install -y git-buildpackage
 apt-get install -y libssl-dev bc kmod cpio pkg-config build-essential
 
-# NOTE: These need to be set after git-buildpackage is installed as the chroot wont have git
+# These need to be set after git-buildpackage is installed as the chroot wont have git
 git config --global user.email "example@example.com"    # for commit -s
 git config --global user.name "l4fame-build-container"
 
@@ -486,12 +486,12 @@ get_update_path Emulation.git && build_via_gbp --git-upstream-branch=master
 # Manifesting has a bad date in debian/changelog that chokes a Perl module.
 # They got more strict in "debian:lastest".  I hate Debian.  For now...
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=795616
-get_update_path tm-manifesting.git && \
-    build_via_gbp --git-upstream-tree=branch --git-upstream-branch=master --git-cleaner=/bin/true
 
 # If we set the git cleaner is "/bin/true/" we don't need to use sed
-# This has the advantage of working for every misnamed month (was breaking an April to)
-#sed -ie 's/July/Jul/' debian/changelog
+# This has the advantage of working for every misnamed month (was breaking on April, etc)
+# sed -ie 's/July/Jul/' debian/changelog
+get_update_path tm-manifesting.git && \
+    build_via_gbp --git-upstream-tree=branch --git-upstream-branch=master --git-cleaner=/bin/true
 
 # The kernel has its own deb build mechanism so ignore return values on...
 get_update_path linux-l4fame.git

--- a/builder.bash
+++ b/builder.bash
@@ -106,6 +106,7 @@ EOF
     # This indicates to the arm64 chroot which repositories need to be built
     if inContainer; then    # mark repositories to be built
         #echo "postbuild=rm ../\$(basename \$(pwd))-AMD-update" >> $HOME/.gbp.conf
+        echo "not needed"
     else
         # In chroot, mark repositories as already built
         echo "postbuild=rm ../\$(basename \$(pwd))-ARM-update" >> $HOME/.gbp.conf

--- a/builder.bash
+++ b/builder.bash
@@ -325,7 +325,7 @@ function build_kernel() {
     # the "NN" in linux-image-4.14.0-l4fame+_4.14.0-l4fame+-NN_amd64.deb.
     rm -f .version  # restarts at 1
 
-    git add .
+    git add -A
     git commit -a -s -m "Removing -dirty"
     log "Now at $(/bin/pwd) ready to make"
     make -j$CORES deb-pkg 2>&1 | tee -a $LOGFILE
@@ -526,7 +526,7 @@ build_kernel
 #--------------------------------------------------------------------------
 # That's all, folks!  Move what worked.
 
-# TODO: Do we want to build the source packages as well?
+# TODO: Do we want to copy the source packages as well?
 copy_built_packages
 #cp $GBPOUT/*.deb $DEBS
 #cp $GBPOUT/*.changes $DEBS
@@ -554,7 +554,6 @@ set -u
 # The next routine should get into a chroot very quickly.
 SUPPRESSAMD=false
 # TODO: Will the script copy break because we are in $BUILD not where $0 is located?
-# TODO: Does this only trigger on the second launch of the container?
 maybe_build_arm
 
 exit 0

--- a/builder.bash
+++ b/builder.bash
@@ -6,6 +6,7 @@
 # TODO: Note, added "..." to every log() call
 # TODO: Note, kernel builds take forever because dpkg-deb doesn't multi-thread
 # TODO: Note, do we want to build the source packages as well?
+# TODO: Note, going to have to switch to git fetch to check for updates.
 
 # This gets copied into a container image and run.  Multiple repos are
 # pulled from GitHub and Debian x86_64 packages created from them.  The
@@ -356,6 +357,7 @@ function maybe_build_arm() {
     log "Next, cp $BUILDER $CHROOT"
     # TODO: This assumes you're in the same dir as the builder script
     # TODO: using "$0" gets the script even if currently executing in build dir
+    # TODO: Makes sense considering the provided Dockerfile
     cp $BUILDER $CHROOT
     chroot $CHROOT $BUILDER \
         'cores=$CORES' 'http_proxy=$http_proxy' 'https_proxy=$https_proxy'

--- a/builder.bash
+++ b/builder.bash
@@ -105,7 +105,7 @@ EOF
     # Insert a postbuild command into the middle of the gbp configuration file
     # This indicates to the arm64 chroot which repositories need to be built
     if inContainer; then    # mark repositories to be built
-        echo "postbuild=rm ../\$(basename \$(pwd))-AMD-update" >> $HOME/.gbp.conf
+        #echo "postbuild=rm ../\$(basename \$(pwd))-AMD-update" >> $HOME/.gbp.conf
     else
         # In chroot, mark repositories as already built
         echo "postbuild=rm ../\$(basename \$(pwd))-ARM-update" >> $HOME/.gbp.conf
@@ -240,7 +240,7 @@ function get_update_path() {
 
     # Only do git work in the container.  Bind links will expose it to chroot.
     if inContainer; then
-        [ -f $(basename "$GITPATH-AMD-update") ] && RUN_UPDATE=yes
+        #[ -f $(basename "$GITPATH-AMD-update") ] && RUN_UPDATE=yes
         # TODO: Should we move to "git fetch" as opposed to "git branch" here?
         if [ ! -d "$GITPATH"  ]; then   # First time
             cd $BUILD
@@ -270,7 +270,8 @@ function get_update_path() {
                 done
             fi
         fi
-        [[ "$RUN_UPDATE" == "yes" ]] && touch /$BUILD/"$BNPREFIX-AMD-update" /$BUILD/"$BNPREFIX-ARM-update"
+        # [[ "$RUN_UPDATE" == "yes" ]] && touch /$BUILD/"$BNPREFIX-AMD-update" /$BUILD/"$BNPREFIX-ARM-update"
+        [[ "$RUN_UPDATE" == "yes" ]] && touch /$BUILD/"$BNPREFIX-ARM-update"
     else
         # In chroot: check if container path above left a sentinel.
         [ -f $(basename "$BNPREFIX-ARM-update") ] && RUN_UPDATE=yes
@@ -486,6 +487,9 @@ set_debuild_config
 
 # This is what works, trial and error, I stopped at first working solution.
 # They might not be optimal or use minimal set of --git-upstream-xxx options.
+
+# TODO: It doesn't seem like there is anything preventing x86 builds when the
+#       repo is un-updated
 
 for REPO in l4fame-node l4fame-manager tm-libfuse tm-librarian; do
     get_update_path ${REPO}.git && build_via_gbp

--- a/builder.bash
+++ b/builder.bash
@@ -448,7 +448,7 @@ set_debuild_config
 # 3. "master", "debian", and "upstream" and I don't know what it does
 # For all other permutations start slinging options.
 
-# Package           Branches of concern "debian" dir src in
+# Package           Branches of concern     "debian" dir    src in
 # Emulation         debian,master           debian          master
 # l4fame-manager    master                  master          n/a
 # l4fame-node       master                  master          n/a

--- a/builder.bash
+++ b/builder.bash
@@ -248,7 +248,7 @@ function get_update_path() {
             # TODO: Shouldn't we move to the next repo as opposed to dying?
             git clone "$REPO" || die "git clone $REPO failed"
             [ -d "$GITPATH" ] || die "git clone $REPO worked but no $GITPATH"
-            TODO: Checkout all the branches at least once to prevent errors
+            # TODO: Checkout all the branches at least once to prevent errors
             cd $GITPATH
             for BRANCH in $(git branch -r | grep -v HEAD | cut -d'/' -f2); do
                 git checkout $BRANCH -- &>/dev/null

--- a/builder.bash
+++ b/builder.bash
@@ -271,7 +271,7 @@ function get_update_path() {
             fi
         fi
         # [[ "$RUN_UPDATE" == "yes" ]] && touch /$BUILD/"$BNPREFIX-AMD-update" /$BUILD/"$BNPREFIX-ARM-update"
-        [[ "$RUN_UPDATE" == "yes" ]] && touch /$BUILD/"$BNPREFIX-ARM-update"
+        touch /$BUILD/"$BNPREFIX-ARM-update"
     else
         # In chroot: check if container path above left a sentinel.
         [ -f $(basename "$BNPREFIX-ARM-update") ] && RUN_UPDATE=yes

--- a/builder.bash
+++ b/builder.bash
@@ -309,7 +309,7 @@ function build_kernel() {
 
     # See scripts/link-vmlinux.  Reset the final numeric suffix counter,
     # the "NN" in linux-image-4.14.0-l4fame+_4.14.0-l4fame+-NN_amd64.deb.
-    # TODO: Check commit e6511d981425cb13b792abdd0524b370ce3fd59d for linux-l4fame repo
+    # NOTE: Check commit e6511d981425cb13b792abdd0524b370ce3fd59d for linux-l4fame repo
     #       the CONFIG_LOCALVERSION_AUTO appends the value of
     #       $(git rev-parse --verify --short HEAD) to the built packages
     #       is this behavior we want or should NN just be 1 always
@@ -367,9 +367,6 @@ function maybe_build_arm() {
 
     BUILDER="/$(basename $0)"   # Here in the container
     log "Next, cp $BUILDER $CHROOT"
-    # TODO: This assumes you're in the same dir as the builder script
-    # TODO: using "$0" gets the script even if currently executing in build dir
-    # TODO: Makes sense considering the provided Dockerfile
     cp $BUILDER $CHROOT
     chroot $CHROOT $BUILDER \
         'cores=$CORES' 'http_proxy=$http_proxy' 'https_proxy=$https_proxy'
@@ -389,6 +386,7 @@ copy_built_packages () {
 
 # NOTE: Has release = stretch here, but the container is pulling from latest
 # NOTE: This has different effects under Ubuntu and Debain
+# NOTE: Set "FROM debian:stretch" in the Dockerfile
 readonly ARMDIR=/arm
 readonly RELEASE=stretch
 readonly CHROOT=$ARMDIR/$RELEASE
@@ -415,8 +413,6 @@ log "$(env | sort)"
 ELAPSED=$(date +%s)
 
 # "docker run ... -e cores=N" or suppressarm=false
-# NOTE: Values set with "-e item=value" can only be set on the first run
-# NOTE: There is no good way to change them without making a new container
 CORES=${cores:-}
 [ "$CORES" ] || CORES=$((( $(nproc) + 1) / 2))
 
@@ -436,11 +432,6 @@ else
     # apt-get install -y linux-image-arm64  Austin's first try?
     # NOTE: Not sure what "linux-image-arm64" gets us. Pulled from Keith's build script
 fi
-
-# TODO: Will move to Dockerfile and push a rebuild
-# TODO: See "Note" section from the following documentation
-# TODO: https://docs.docker.com/engine/reference/builder/#env
-export DEBIAN_FRONTEND=noninteractive   # Should be in Dockerfile
 
 apt-get update && apt-get upgrade -y
 apt-get install -y git-buildpackage
@@ -524,8 +515,6 @@ for (( I=0; I < ${#WARNINGS[@]}; I++ )); do log "${WARNINGS[$I]}"; done
 log "\nERRORS:"
 for (( I=0; I < ${#ERRORS[@]}; I++ )); do log "${ERRORS[$I]}"; done
 
-# TODO: If there are any errors in the x86 build we just skip the arm build?
-# TODO: Seems like overkill, ask why
 [ ${#ERRORS[@]} -ne 0 ] && die "Error(s) occurred"
 
 set -u

--- a/builder.bash
+++ b/builder.bash
@@ -456,8 +456,6 @@ set_gbp_config
 set_debuild_config
 
 
-# TODO: The Dockerfile uses debian:stretch, is this next block still relevant?
-
 # Using image debian:latest (vs :stretch) seems to have brought along
 # a more pedantic gbp that is less forgiving of branch names.
 # gbp will take branches like this:
@@ -494,17 +492,17 @@ get_update_path libfam-atomic.git && build_via_gbp --git-upstream-tree=branch
 get_update_path tm-hello-world.git && build_via_gbp --git-upstream-tree=branch --git-upstream-branch=debian
 get_update_path Emulation.git && build_via_gbp --git-upstream-branch=master
 
-# TODO: The Dockerfile uses debian:stretch, is this next block still relevant?
 # Manifesting has a bad date in debian/changelog that chokes a Perl module.
 # They got more strict in "debian:lastest".  I hate Debian.  For now...
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=795616
 get_update_path tm-manifesting.git && \
     build_via_gbp --git-upstream-tree=branch --git-upstream-branch=master --git-cleaner=/bin/true
 
-# TODO: Do we still need the call to "sed" if the git cleaner is "/bin/true/"?
+# If we set the git cleaner is "/bin/true/" we don't need to use sed
+# This has the advantage of working for every misnamed month (was breaking an April to)
 #sed -ie 's/July/Jul/' debian/changelog
 
-# The kernel has its own deb build mechanism so ignore retval on...
+# The kernel has its own deb build mechanism so ignore return values on...
 get_update_path linux-l4fame.git
 build_kernel
 

--- a/builder.bash
+++ b/builder.bash
@@ -223,19 +223,19 @@ function get_update_path() {
 
     # Only do git work in the container.  Bind links will expose it to chroot.
     if inContainer; then
-        # NOTE: Check if previous build has failed
+        # Check if previous build has failed
         [ -f "/$BUILD/$BNPREFIX-AMD-update" ] && RUN_UPDATE=yes
         if [ ! -d "$GITPATH"  ]; then   # First time
             cd $BUILD
             log "Cloning $REPO"
             git clone "$REPO" || die "git clone $REPO failed"
             [ -d "$GITPATH" ] || die "git clone $REPO worked but no $GITPATH"
-            # NOTE: Checkout all the branches at least once to prevent gbp errors
+            # Checkout all the branches at least once to prevent gbp errors
             cd $GITPATH
             for BRANCH in $(git branch -r | grep -v HEAD | cut -d'/' -f2); do
                 git checkout $BRANCH -- &>/dev/null
             done
-            # NOTE: Checkout original HEAD branch
+            # Checkout original HEAD branch
             git checkout $(git branch -r | grep HEAD | cut -d'/' -f3) -- &>/dev/null
             RUN_UPDATE=yes
         else            # Update any branches that need it.

--- a/builder.bash
+++ b/builder.bash
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
 
-# NOTE: all back-ticks have been swapped for $(...)
-# NOTE: indents on various loops and functions have been updated
-# NOTE: all tabs have been swapped to 4 spaces
-# NOTE: added "..." to every log() call
-# NOTE: kernel builds take forever because dpkg-deb doesn't multi-thread
-# NOTE: do we want to build the source packages as well?
-# NOTE: going to have to switch to git fetch to check for updates.
-# NOTE: changed what flags most of the repos are using
-
 # This gets copied into a container image and run.  Multiple repos are
 # pulled from GitHub and Debian x86_64 packages created from them.  The
 # resulting .deb files are deposited in the "debs" volume from the
@@ -86,7 +77,6 @@ function suppressed() {
 ###########################################################################
 # Sets the configuration file for gbp.  Note that "debian/rules" is an
 # executable file under fakeroot, with a shebang line of "#!/usr/bin/make -f"
-# NOTE: added "force-create = True" for building source packages as well
 
 GBPOUT=/gbp-build-area/
 

--- a/builder.bash
+++ b/builder.bash
@@ -107,8 +107,6 @@ EOF
 }
 
 ###########################################################################
-# Should only be run in the container?
-# NOTE: Needs to be run the chroot as well to configure arm debuild
 # Sets the configuration file for debuild.
 # Also checks for a signing key to build packages with
 
@@ -116,14 +114,11 @@ function set_debuild_config () {
     # Check for signing key
     if [ -f $KEYFILE ]; then
         # Remove old keys, import new one, get the key uid
-        # NOTE: added "-f" to rm to suppress errors, needed?
         rm -rf $HOME/.gnupg
         gpg --import $KEYFILE
         GPGID=$(gpg -K | grep uid | cut -d] -f2)
-        # NOTE: Remove the "-b" flag
         echo "DEBUILD_DPKG_BUILDPACKAGE_OPTS=\"-k'$GPGID' -i -j$CORES\"" > $HOME/.devscripts
     else
-        # NOTE: Remove the "-b" flag
         echo "DEBUILD_DPKG_BUILDPACKAGE_OPTS=\"-us -uc -i -j$CORES\"" > $HOME/.devscripts
     fi
 }

--- a/builder.bash
+++ b/builder.bash
@@ -61,10 +61,13 @@ function collect_errors() {
 # environment.  The container always has it, the chroot, maybe not.
 # This breaks down for exec -it bash.   Okay, go back.
 
+# TODO: Should we just create an indicator file using the Dockerfile and check for that?
 function inContainer() {
     TMP=$(grep 2>&1)
     [[ "$TMP" =~ '.*not found$' ]] && return 1 # no grep == not container
     [ ! -d /proc ] && return 1  # again, dodgy
+    # TODO: only works if we have this run command in the Dockerfile
+    # [ ! -f /.in_docker_container ] && return 1
     [ $(ls /proc | wc -l) -gt 0 ]
     return $?
 }


### PR DESCRIPTION
The build script now contains logic for checking if the repo needs a rebuild or not.
The build script also builds all the source packages now.
The Dockerfile now contains a better indicator for chroot/container.
The README no longer contains references to the out of date public dockerhub image. 